### PR TITLE
Add Windows launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Once it's done install the **requirements.txt**:
 
     pip install -r requirements.txt
 
+Alternatively you can simply double-click **run.bat**. It will create
+a `.venv` folder if needed, install the required packages and launch the
+Gradio interface.
+
 You can dowload the [Models](https://huggingface.co/SmilingWolf) and the [selected_tags.csv](https://huggingface.co/SmilingWolf/wd-v1-4-swinv2-tagger-v2/resolve/main/selected_tags.csv) and put both on the './Models' folder. If you download the models but don't put them in the folder, specify the path (instructions below) otherwise the script will download the missing resources
 
 ## Usage

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,12 @@
+@echo off
+
+if not exist ".venv" (
+    python -m venv .venv
+)
+
+call .venv\Scripts\activate
+
+pip install -r requirements.txt gradio tqdm requests
+
+python app_gradio.py
+pause


### PR DESCRIPTION
## Summary
- add a Windows `run.bat` launcher script that creates a venv, installs requirements and runs the Gradio app
- document how to use the launcher from the README

## Testing
- `python -m py_compile wd-tagger.py app_gradio.py`

------
https://chatgpt.com/codex/tasks/task_e_687427ac1318832bb9749a1fd06946f9