### PR TITLE
Fix dependencies and gradio compatibility

### DIFF
--- a/app_gradio.py
+++ b/app_gradio.py
@@ -118,7 +118,7 @@ def main():
     with gr.Blocks() as demo:
         gr.Markdown("## WD14 Batch Tagger")
         model_dropdown = gr.Dropdown(list(MODELS.keys()), value="wd-swinv2-tagger-v3", label="Model")
-        image_input = gr.File(file_types=[".png", ".jpg", ".jpeg"], label="Images", multiple=True)
+        image_input = gr.File(file_types=[".png", ".jpg", ".jpeg"], label="Images", file_count="multiple")
         output = gr.Textbox(label="Tags")
         run_btn = gr.Button("Tag Images")
         run_btn.click(fn=process_images, inputs=[image_input, model_dropdown], outputs=output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 piexif==1.1.3
 onnxruntime-gpu==1.12.0
+numpy<2
 opencv-python
 pandas
 pillow==9.0.0
-gradio
+gradio>=4.26
 tqdm
 requests
 torch


### PR DESCRIPTION
## Summary
- ensure numpy <2 for onnxruntime compatibility
- require gradio >=4.26
- update Gradio File component usage

## Testing
- `python3 -m py_compile app_gradio.py wd-tagger.py`

------
https://chatgpt.com/codex/tasks/task_e_68743902b1a8832b97839c6bd51a0050